### PR TITLE
Adding intial workflow for GitHub Actions with Terraform

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,52 @@
+# tf-eks-helm-automation - CoPilot Instructions
+
+This repository contains Terraform configurations and Helm charts for automating the deployment of applications on Amazon EKS (Elastic Kubernetes Service).
+
+## Project Context
+- GitHub Actions for CI/CD workflows.
+- Terraform for infrastructure as code.
+- Helm for managing Kubernetes applications.
+
+## Coding Standards
+- Use Terraform best practices for resource naming and organisation.
+- Follow consistent file naming conventions.
+- Follow AWS resource naming conventions, with consistent prefixes for resources.
+- Use "Name" tags for all AWS resources.
+- Use data sources to reference existing resources where applicable.
+- Include comprehensive variable descriptions with type constraints.
+- Add output values for important resource attributes.
+- Give clear descriptions for any resources and modules.
+- Suffix AWS resource descriptions with " - Managed by Terraform".
+
+## Variables
+- Use `variables.tf` to define all input variables.
+- Use `terraform.tfvars.example` to provide example values for variables.
+- Use `sensitive = true` for sensitive variables.
+- Use terraform fmt and terraform validate before committing changes.
+- Document resources with inline comments to describe purpose.
+
+## AWS Services
+- IAM for permission management.
+- EKS for Kubernetes clusters.
+- S3 for state storage.
+
+## Security Considerations
+- Use IAM roles with least privilege.
+- Store sensitive data in AWS Secrets Manager or SSM Parameter Store.
+- Secure S3 buckets with appropriate policies, and ensure they are private.
+- Do not use wildcard permissions in IAM policies.
+- Implement security groups with least privilege access and specific ports and protocols.
+- Use encryption for sensitive data at rest and in transit.
+- Use S3 based locking for Terraform state files.
+
+## Development Guidelines
+When suggesting code changes or new features, consider:
+1. **Quality**: Ensure readability, maintainability, and proper documentation.
+2. **Security First**: All security considerations must be implemented by default.
+3. **Environment Separation**: Support for multiple environments (e.g. dev, staging, prod) should be considered.
+4. **Error Handling**: Implement proper error handling and logging.
+5. **Logging and Monitoring**: Ensure that logging and monitoring are set up for all critical components.
+6. **Backward Compatibility**: Ensure that changes do not break existing functionality unless explicitly stated.
+7. **Testing**: Include unit tests and integration tests where applicable.
+8. **Performance**: Consider performance implications of changes, especially in resource-intensive operations.
+9. **Documentation**: Update README files and inline comments to reflect changes made.

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -1,0 +1,67 @@
+name: Terraform Template
+
+on:
+  workflow_call:
+    inputs:
+      action:
+        required: true
+        type: string
+        description: 'The action to perform, e.g., "apply", "plan", "destroy".'
+      tf_directory:
+        required: true
+        type: string
+        description: 'The directory containing the Terraform configuration files.'
+      stack:
+        required: false
+        type: string
+        default: 'aws'
+        description: 'The stack name for the Terraform execution.'
+      environment:
+        required: true
+        type: string
+        description: 'The environment for the Terraform execution, e.g., "dev", "staging", "prod".'
+      aws_region:
+        required: false
+        type: string
+        default: 'eu-west-2'
+        description: 'The AWS region to configure credentials for.'
+      role:
+        required: false
+        type: string
+        default: 'arn:aws:iam::299858989921:role/github-actions-oidc-role'
+        description: 'The AWS IAM role to assume for the GitHub Actions workflow.'
+      state_bucket_prefix:
+        required: false
+        type: string
+        default: 's3-tf-eks-helm-automation-state'
+        description: 'The prefix for the S3 bucket used for Terraform state.'
+
+jobs:
+  test:
+    name: 'Test AWS Terraform Code'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ github.workspace }}/${{ inputs.tf_directory }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: latest
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4.1.0
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ inputs.role }}
+          role-session-name: GitHubActionsSession
+      - name: Initialise Terraform
+        run: |
+          account_id=$(aws account get-account-information --query AccountId --output text)
+          state_bucket="${{ inputs.state_bucket_prefix }}-$account_id-${{ inputs.aws_region }}"
+          terraform init -input=false -backend-config="bucket=$state_bucket" --backend-config="key=${{ inputs.stack }}/terraform.tfstate" --backend-config="region=${{ inputs.aws_region }}"
+      - name: Check Format
+        run: terraform fmt -check --recursive || echo "::warning file=terraform-aws::Terraform format check failed"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,19 @@
+name: 'Full Deployment Workflow'
+
+on:
+  push:
+    branches: [ "feature/*" ]
+  pull_request:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  aws-terraform-plan:
+    uses: ./.github/workflows/terraform-action.yaml
+    with:
+      action: plan
+      tf_directory: terraform-aws
+      environment: dev
+      aws_region: eu-west-2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Terraform state
+**.tfstate
+**.tfstate.*
+**/.terraform/
+*/.terraform.lock.hcl
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+
+# Sensitive files
+*.pem
+*.key
+*.crt
+
+# Local environment files
+.env
+.env.*
+
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Logs
+*.log
+
+# VSCode
+.vscode/
+
+# Python virtualenv (if any scripts/tools)
+venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# EKS Project
+
+This project contains code and resources for working with Amazon Elastic Kubernetes Service (EKS).
+
+## Features
+
+- Infrastructure as Code for EKS clusters
+- Automation scripts and configuration files
+- Example usage patterns
+
+## Getting Started
+
+1. Setup IAM to trust GitHub's OIDC provider.
+
+## Requirements
+
+- AWS CLI
+- kubectl
+- Terraform or CloudFormation (if applicable)
+
+## License
+
+See LICENSE file for details.

--- a/terraform-aws/variables.tf
+++ b/terraform-aws/variables.tf
@@ -1,0 +1,10 @@
+variable "environment" {
+  description = "Environment being deployed."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, production."
+  }
+}

--- a/terraform-aws/versions.tf
+++ b/terraform-aws/versions.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+
+  backend "s3" {
+    encrypt      = true
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      environment = var.environment
+      project     = "tf-eks-helm-automation"
+      owner       = "Jaluri@outlook.com"
+    }
+  }
+}

--- a/terraform-prereqs/iam_github_actions.tf
+++ b/terraform-prereqs/iam_github_actions.tf
@@ -1,0 +1,48 @@
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+  client_id_list = [
+    "sts.amazonaws.com"
+  ]
+  thumbprint_list = [
+    "D89E3BD43D5D909B47A18977AA9D5CE36CEE184C" # GitHub's OIDC thumbprint
+  ]
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values = [
+        "sts.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:${var.github_org}/${var.github_repo}:environment:*"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name               = "github-actions-oidc-role"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role_policy.json
+
+  tags = {
+    Name = "github-actions-oidc-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_attach" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess" # Adjust as needed
+}

--- a/terraform-prereqs/outputs.tf
+++ b/terraform-prereqs/outputs.tf
@@ -1,0 +1,15 @@
+output "s3_bucket_arn" {
+  description = "The ARN of the S3 bucket used for Terraform state."
+  value       = aws_s3_bucket.tf_state.arn
+}
+
+output "oidc_provider_arn" {
+  description = "The ARN of the OIDC provider created for GitHub Actions."
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+
+}
+
+output "iam_role_arn" {
+  description = "The ARN of the IAM role created for GitHub Actions."
+  value       = aws_iam_role.github_actions.arn
+}

--- a/terraform-prereqs/s3_state.tf
+++ b/terraform-prereqs/s3_state.tf
@@ -1,0 +1,77 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "tf_state" {
+  bucket        = "s3-tf-eks-helm-automation-state-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}"
+  force_destroy = true
+
+  tags = {
+    Name = "terraform-state-bucket"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tf_state_versioning" {
+  bucket = aws_s3_bucket.tf_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state_encryption" {
+  bucket = aws_s3_bucket.tf_state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tf_state_block" {
+  bucket                  = aws_s3_bucket.tf_state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "tf_state_policy" {
+  bucket = aws_s3_bucket.tf_state.id
+  policy = data.aws_iam_policy_document.tf_state_policy.json
+}
+
+data "aws_iam_policy_document" "tf_state_policy" {
+  statement {
+    sid    = "DenyUnEncryptedObjectUploads"
+    effect = "Deny"
+    actions = [
+      "s3:PutObject"
+    ]
+    resources = [
+      "${aws_s3_bucket.tf_state.arn}/*"
+    ]
+    condition {
+      test     = "StringNotEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["AES256"]
+    }
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "tf_state_lifecycle" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    id     = "expire-old-versions"
+    status = "Enabled"
+
+    filter {} # Required by provider when no prefix or filter is specified
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30 # Remove noncurrent (old) versions after 30 days
+    }
+  }
+}

--- a/terraform-prereqs/terraform.tfvars
+++ b/terraform-prereqs/terraform.tfvars
@@ -1,0 +1,2 @@
+github_org  = "Rivera-py" # Add info here
+github_repo = "tf-eks-helm-automation" # Add info here

--- a/terraform-prereqs/variables.tf
+++ b/terraform-prereqs/variables.tf
@@ -1,0 +1,9 @@
+variable "github_org" {
+  description = "GitHub organization for OIDC"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository for OIDC"
+  type        = string
+}

--- a/terraform-prereqs/versions.tf
+++ b/terraform-prereqs/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      environment = "support"
+      project     = "tf-eks-helm-automation"
+      owner       = "Jaluri@outlook.com"
+    }
+  }
+}


### PR DESCRIPTION
1. Added `terraform-prereq` folder to install static resources to be used the rest of the project
    - Added S3 bucket for statefile
    - Added GitHub OIDC provider
    - Added Role for GH Actions to use
2. Created an initial repo for AWS terraform stack `terraform-aws`
3. Created a rough workflow with reusable terraform deployment workflow, which can successfully `init`
 
**Successful Run:** https://github.com/Rivera-py/tf-eks-helm-automation/actions/runs/16529039061/job/46749589278